### PR TITLE
Updated start location permission to not show exception on missing permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,7 +2,7 @@ name: Lint + Test
 
 on:
   pull_request:
-    branches: [ master ]
+    branches: [ master, main ]
     types: [opened, synchronize, reopened, labeled, unlabeled]
 
 jobs:

--- a/android/src/main/kotlin/com/almoullim/background_location/BackgroundLocationService.kt
+++ b/android/src/main/kotlin/com/almoullim/background_location/BackgroundLocationService.kt
@@ -200,7 +200,8 @@ class BackgroundLocationService : MethodChannel.MethodCallHandler,
             "start_location_service" -> {
                 if (!checkPermissions()) {
                     requestPermissions()
-                    throw Exception("Permissions missing from location")
+                    result.error("permissionError", "Permissions missing for location service to start fully")
+                    return
                 }
 
                 var locationCallback: Long? = 0L


### PR DESCRIPTION
Should fix incorrect error on start location call: https://github.com/BWMuller/background_location/issues/1

Additional changes will be needed in the future to allow not using background location permission at all